### PR TITLE
solved issue #6 Fix: Clear console or add a separator before printing the invoice

### DIFF
--- a/service_counter.py
+++ b/service_counter.py
@@ -146,7 +146,8 @@ while is_creating_invoices:
     service_cost += float(service_labour_cost)
 
     # Print invoice
-    # TODO - Clear the console screen or add a dashed line before we print the invoice.
+    # Add a visual separator before printing the invoice
+    print("-" * 60)
     if language_choice == "1":
         print_english_language_invoice()
     else:


### PR DESCRIPTION
Changes Made:
Removed the TODO comment on line 149 that requested adding a visual separator
Added a new descriptive comment: # Add a visual separator before printing the invoice
Implemented a simple but effective visual separator using: print("-" * 60)